### PR TITLE
Enabling loading PDFs from http/https

### DIFF
--- a/PDFLoader/PDFLoader/UnitySample/PDFLoaderApp/Assets/PDFLoader/Scripts/PdfLoader.cs
+++ b/PDFLoader/PDFLoader/UnitySample/PDFLoaderApp/Assets/PDFLoader/Scripts/PdfLoader.cs
@@ -63,7 +63,10 @@ namespace PDFLoader
 
             CreatePdf();
 
-            LoadPDF(FileName);
+            if (!string.IsNullOrEmpty(FileName))
+            {
+                LoadPDF(FileName);
+            }
         }
 
         protected override void OnDisable()


### PR DESCRIPTION
Making some changes to the PDFLoader:

- You can now download pdfs via http or https.  If the filename begins with http or https, the plugin will make a web request and download the file.
- Updated pdf plugin scripts to avoid loading a pdf on enable, if the filename is null or empty